### PR TITLE
Allow skipping of deletes to be synced to the data lake

### DIFF
--- a/businessCentral/src/ADLSEExecution.Codeunit.al
+++ b/businessCentral/src/ADLSEExecution.Codeunit.al
@@ -155,11 +155,15 @@ codeunit 82569 "ADLSE Execution"
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
         ADLSEDeletedRecord: Record "ADLSE Deleted Record";
     begin
+        // exit function for tables that you do not wish to sync deletes for
+        // you should also consider not registering for deletes for the table in the function GetDatabaseTableTriggerSetup above.
+        // if RecRef.Number = Database::"G/L Entry" then
+        //     exit;
+
         // check if table is to be tracked.
         if not ADLSETableLastTimestamp.ExistsUpdatedLastTimestamp(RecRef.Number) then
             exit;
 
         ADLSEDeletedRecord.TrackDeletedRecord(RecRef);
     end;
-
 }


### PR DESCRIPTION
Records may be deleted from the BC database for house-keeping purposes. But the data could nevertheless be important and needs to be archived. The following approach demonstrates how you can "customize" the bc2adls extension to NOT delete the same data on the synced data lake WHILE you delete it from Business Central. This is particularly useful for tables like posted documents or entries where records are deleted for the express purpose of archival and not as part of the day to day operations.