### PR TITLE
Added fail activity to Consolidation_CheckForDeltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Learn more,
 - [Installation and configuration](/.assets/Setup.md)
 - [Running the analytics](/.assets/RunningAnalytics.md)
 
+## Latest notable changes
+
+Date | Changes
+--------------- | ---
+3rd May, 2022 | The [Consolidation_CheckForDeltas](/synapse/pipeline/Consolidation_CheckForDeltas.json) pipeline now contains a fail activity that is triggered when no directory is found in `/deltas/` for an entity listed in the `deltas.manifest.cdm.json`. This may occur when no new deltas have been exported since the last execution of the consolidation pipeline. Other parallel pipelin runs are not affected.
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/synapse/pipeline/Consolidation_CheckForDeltas.json
+++ b/synapse/pipeline/Consolidation_CheckForDeltas.json
@@ -59,6 +59,22 @@
                         "value": "@activity('CheckEntityExistence').output.exists",
                         "type": "Expression"
                     },
+                    "ifFalseActivities": [
+                        {
+                            "name": "FailIfEntityNotFound",
+                            "description": "Fails the current iteration over the entities in the deltas manifest if no directory is found for the current entity",
+                            "type": "Fail",
+                            "dependsOn": [],
+                            "userProperties": [],
+                            "typeProperties": {
+                                "message": {
+                                    "value": "@concat('Entity with name ', pipeline().parameters.entityName, ' was found in the deltas.manifest.cdm.json but no directory with that name was found in ', pipeline().parameters.containerName, '/deltas/. This may be the case if no new deltas have been exported.')",
+                                    "type": "Expression"
+                                },
+                                "errorCode": "404"
+                            }
+                        }
+                    ],
                     "ifTrueActivities": [
                         {
                             "name": "ConsolidateEntity",


### PR DESCRIPTION
Added fail activity to Consolidation_CheckForDeltas pipeline to ensure that the pipeline does not complete successfully if an entity named in the deltas.manifest.csm.json has no corresponding directory in /deltas/. 
With the fail activity, the pipeline (for that one entity) will fail, without affecting the other parallel executions of the pipeline.