### PR TITLE
Raised ForEach activity batchCount from default (20) to maximum (50)

### DIFF
--- a/synapse/pipeline/Consolidation_AllEntities.json
+++ b/synapse/pipeline/Consolidation_AllEntities.json
@@ -57,6 +57,7 @@
                         "type": "Expression"
                     },
                     "isSequential": false,
+                    "batchCount": 50,
                     "activities": [
                         {
                             "name": "ConsolidateNewDeltas",


### PR DESCRIPTION
By default, the ForEach activity executes in batches of 20 parallel inner runs. This can be increased to a maximum of 50 by setting the batchCount parameter. See https://docs.microsoft.com/en-us/azure/data-factory/control-flow-for-each-activity