### PR TITLE
Converting from indirect to direct permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ More details:
 
 Pull request | Changes
 --------------- | ---
+[31](https://github.com/microsoft/bc2adls/pull/31) | Permissions corrected to direct permissions.
 [28](https://github.com/microsoft/bc2adls/pull/28) | The AL app is upgraded to Dynamics 365 Business Central version 20. An archive has been created to keep the older versions at [the archived folder](/archived/).
 [23](https://github.com/microsoft/bc2adls/pull/23) | The setting in [Consolidation_OneEntity](/synapse/pipeline/Consolidation_OneEntity.json) that limited concurrent execution of the pipeline to one instance has been removed. Now, an infinite number of pipeline instances is allowed to run concurrently. 
 [20](https://github.com/microsoft/bc2adls/pull/20) | Data on the lake can be chosen to be stored on the [Parquet](https://docs.microsoft.com/en-us/azure/data-factory/format-parquet) format, thus improving its fidelity to its original in Business Central.

--- a/businessCentral/permissions/ADLSEExecute.PermissionSet.al
+++ b/businessCentral/permissions/ADLSEExecute.PermissionSet.al
@@ -9,10 +9,10 @@ permissionset 82561 "ADLSE - Execute"
     Assignable = true;
     Caption = 'Azure Data Lake Storage - Execute';
 
-    Permissions = tabledata "ADLSE Setup" = rm,
-                  tabledata "ADLSE Table" = rm,
-                  tabledata "ADLSE Field" = r,
-                  tabledata "ADLSE Deleted Record" = r,
-                  tabledata "ADLSE Current Session" = rimd,
-                  tabledata "ADLSE Table Last Timestamp" = rimd;
+    Permissions = tabledata "ADLSE Setup" = RM,
+                  tabledata "ADLSE Table" = RM,
+                  tabledata "ADLSE Field" = R,
+                  tabledata "ADLSE Deleted Record" = R,
+                  tabledata "ADLSE Current Session" = RIMD,
+                  tabledata "ADLSE Table Last Timestamp" = RIMD;
 }

--- a/businessCentral/permissions/ADLSESetup.PermissionSet.al
+++ b/businessCentral/permissions/ADLSESetup.PermissionSet.al
@@ -9,10 +9,10 @@ permissionset 82560 "ADLSE - Setup"
     Assignable = true;
     Caption = 'Azure Data Lake Storage - Setup';
 
-    Permissions = tabledata "ADLSE Setup" = rimd,
-                  tabledata "ADLSE Table" = rimd,
-                  tabledata "ADLSE Field" = rimd,
-                  tabledata "ADLSE Deleted Record" = rd,
-                  tabledata "ADLSE Current Session" = r,
-                  tabledata "ADLSE Table Last Timestamp" = rid;
+    Permissions = tabledata "ADLSE Setup" = RIMD,
+                  tabledata "ADLSE Table" = RIMD,
+                  tabledata "ADLSE Field" = RIMD,
+                  tabledata "ADLSE Deleted Record" = RD,
+                  tabledata "ADLSE Current Session" = R,
+                  tabledata "ADLSE Table Last Timestamp" = RID;
 }

--- a/businessCentral/permissions/ADLSETrackDelete.PermissionSet.al
+++ b/businessCentral/permissions/ADLSETrackDelete.PermissionSet.al
@@ -9,5 +9,5 @@ permissionset 82562 "ADLSE - Track Delete"
     Assignable = true;
     Caption = 'Azure Data Lake Storage - Track Delete';
 
-    Permissions = tabledata "ADLSE Deleted Record" = i;
+    Permissions = tabledata "ADLSE Deleted Record" = I;
 }


### PR DESCRIPTION
The permissions were set to indirect permissions by mistake. Converting these to direct permissions allows a BC user to fully complete the tasks.