### PR TITLE
No need to insert the fields when inserting the table. As the fields …

### DIFF
--- a/businessCentral/src/ADLSETable.Table.al
+++ b/businessCentral/src/ADLSETable.Table.al
@@ -38,7 +38,6 @@ table 82561 "ADLSE Table"
         ADLSETableField: Record "ADLSE Field";
     begin
         CheckTableOfTypeNormal(Rec."Table ID");
-        ADLSETableField.InsertForTable(Rec);
     end;
 
     trigger OnDelete()


### PR DESCRIPTION
…are refreshed when opening the Fields menu on the table, i.e., when user decides to select which fields to export.