### PR TITLE
Form.RunModal Error when picking fields for Tables

### DIFF
--- a/businessCentral/src/ADLSESetup.Codeunit.al
+++ b/businessCentral/src/ADLSESetup.Codeunit.al
@@ -36,6 +36,7 @@ codeunit 82560 "ADLSE Setup"
     begin
         ADLSEField.SetRange("Table ID", ADLSETable."Table ID");
         ADLSEField.InsertForTable(ADLSETable);
+        Commit(); // changes made to the field table go into the database before RunModal is called
         Page.RunModal(Page::"ADLSE Setup Fields", ADLSEField, ADLSEField.Enabled);
     end;
 


### PR DESCRIPTION
When opening fields page, a RunModal is called after refreshing the fields in the database. Therefore a COMMIT is added to ensure that the data to be read by the page is the latest one.