### PR TITLE
Secrets exposed on page

### DIFF
--- a/businessCentral/app.json
+++ b/businessCentral/app.json
@@ -4,7 +4,7 @@
   "publisher":  "The bc2adls team, Microsoft Denmark",
   "brief":  "Sync data from Business Central to the Azure storage",
   "description":  "Exports data in chosen tables to the Azure Data Lake and keeps it in sync by incremental updates. Before you use this tool, please read the SUPPORT.md file at https://github.com/microsoft/bc2adls.",
-  "version":  "1.2.2.1",
+  "version":  "1.2.3.1",
   "privacyStatement":  "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA":  "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help":  "https://go.microsoft.com/fwlink/?LinkId=724011",

--- a/businessCentral/src/ADLSESetup.Page.al
+++ b/businessCentral/src/ADLSESetup.Page.al
@@ -228,8 +228,6 @@ page 82560 "ADLSE Setup"
         ADLSECredentials.Init();
         StorageTenantID := ADLSECredentials.GetTenantID();
         StorageAccount := ADLSECredentials.GetStorageAccount();
-        ClientID := ADLSECredentials.GetClientID();
-        ClientSecret := ADLSECredentials.GetClientSecret();
     end;
 
     trigger OnAfterGetRecord()


### PR DESCRIPTION
Client ID and Client Secret could be read using a page SOAP request.
So removing the code that fetches the secret. Only edits to the secrets will be allowed. 