### PR TITLE
Decimal values get rounded off to 2 decimal places and lose precision 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ More details:
 
 Pull request | Changes
 --------------- | ---
+[59](https://github.com/microsoft/bc2adls/pull/59) | The default rounding principles caused the consolidated data to have a maximum of two decimal places even though the data in the `deltas` may have had higher decimal precision. Added an applied trait to all decimal fields so that they account for upto 5 decimal places. 
 [54](https://github.com/microsoft/bc2adls/pull/54) | Fixes irregularities on the System Audit fields. (1) Very old records do not appear in the lake sometimes because the `SystemCreatedAt` field is set to null. This field is now artificaly initialized to a date so that it appears in the lake, and (2) The `SystemID` field may be repeated over different records belonging to different companies in the same table. Thus, the uniqueness contraint has been fixed. 
 [49](https://github.com/microsoft/bc2adls/pull/49) | Entities using the Parquet file format can now automatically be registered as a shared metadata table that is managed in Spark but can also be queried using Serverless SQL. You can find the full feature guide [here](/.assets/SharedMetadataTables.md).
 [47](https://github.com/microsoft/bc2adls/pull/47) | The ability to simultaneously export data from multiple companies has been introduced. This is expected to save time and effort in cases which required users to sequence the runs for different companies one after the other.  

--- a/businessCentral/app.json
+++ b/businessCentral/app.json
@@ -4,7 +4,7 @@
   "publisher":  "The bc2adls team, Microsoft Denmark",
   "brief":  "Sync data from Business Central to the Azure storage",
   "description":  "Exports data in chosen tables to the Azure Data Lake and keeps it in sync by incremental updates. Before you use this tool, please read the SUPPORT.md file at https://github.com/microsoft/bc2adls.",
-  "version":  "1.2.3.1",
+  "version":  "1.2.4.1",
   "privacyStatement":  "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA":  "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help":  "https://go.microsoft.com/fwlink/?LinkId=724011",

--- a/businessCentral/src/ADLSEUtil.Codeunit.al
+++ b/businessCentral/src/ADLSEUtil.Codeunit.al
@@ -259,53 +259,6 @@ codeunit 82564 "ADLSE Util"
         Result := Result.Replace(StrSubstNo(WholeSecondsTok, SecondsText), StrSubstNo(FractionSecondsTok, WholeSecondsText, MillisecondsText));
     end;
 
-    procedure GetCDMAttributeDetails(Type: FieldType; var DataFormat: Text; var AppliedTraits: JsonArray)
-    begin
-        DataFormat := '';
-        Clear(AppliedTraits);
-
-        DataFormat := GetCDMDataFormat(Type);
-    end;
-
-    local procedure GetCDMDataFormat(Type: FieldType): Text
-    begin
-        // Refer https://docs.microsoft.com/en-us/common-data-model/sdk/list-of-datatypes
-        // Refer https://docs.microsoft.com/en-us/common-data-model/1.0om/api-reference/cdm/dataformat
-        case Type of
-            FieldType::BigInteger:
-                exit('Int64');
-            FieldType::Date:
-                exit('Date');
-            FieldType::DateFormula:
-                exit(GetCDMDataFormat_String());
-            FieldType::DateTime:
-                exit('DateTime');
-            FieldType::Decimal:
-                exit('Decimal');
-            FieldType::Duration:
-                exit('DateTimeOffset');
-            FieldType::Integer:
-                exit('Int32');
-            FieldType::Option:
-                exit(GetCDMDataFormat_String());
-            FieldType::Time:
-                exit('Time');
-            FieldType::Boolean:
-                exit('Boolean');
-            FieldType::Code:
-                exit(GetCDMDataFormat_String());
-            FieldType::Guid:
-                exit('Guid');
-            FieldType::Text:
-                exit(GetCDMDataFormat_String());
-        end;
-    end;
-
-    local procedure GetCDMDataFormat_String(): Text
-    begin
-        exit('String');
-    end;
-
     procedure AddSystemFields(var FieldIdList: List of [Integer])
     var
         RecRef: RecordRef;


### PR DESCRIPTION
 The default rounding principles caused the consolidated data to have a maximum of two decimal places even though the data in the `deltas` may have had higher decimal precision. Added an applied trait to all decimal fields so that they account for upto 5 decimal places. 