### PR TITLE
Disabled fields cannot be exported

### DIFF
--- a/.assets/Execution.md
+++ b/.assets/Execution.md
@@ -4,7 +4,7 @@ Now that the steps to setup the tool are complete, let's look at how to run it. 
 The export process makes incremental updates to the data lake, based on the amount of changes (adds/ modifies/ deletes) made in BC since the last run. Open the `Page 82560 - Export to Azure Data Lake Storage` and add some tables that should be exported at the bottom grid of [the page](/.assets/bcAdlsePage.png). Do not forget to explicitly (and judiciously) select the fields in the table that should be exported.
 
 > **<em>Note</em>** 
-> 1. BLOB, Flow and Filter fields as well as the fields that have been Obsoleted are not supported.
+> 1. BLOB, Flow and Filter fields as well as the fields that have been Obsoleted or disabled are not supported.
 > 2. Records created before the time when [the `SystemCreatedAt` audit field](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-table-system-fields#audit) was introduced, have the field set to null. When exporting, there is an artificial value of 01 Jan 1900 set on the field notwithstanding the timezone of the deployment. 
 
 Click on the `Export` action at the top of the page. This spawns multiple sessions that export each table in parallel and uploads only the incremental updates to the data since the last export. When none of the table rows have a `Last exported status` of `In process`, it indicates that the export process has completed. You should be able to see the data through the CDM endpoint: `deltas.cdm.manifest.json`.

--- a/businessCentral/app.json
+++ b/businessCentral/app.json
@@ -4,7 +4,7 @@
   "publisher":  "The bc2adls team, Microsoft Denmark",
   "brief":  "Sync data from Business Central to the Azure storage",
   "description":  "Exports data in chosen tables to the Azure Data Lake and keeps it in sync by incremental updates. Before you use this tool, please read the SUPPORT.md file at https://github.com/microsoft/bc2adls.",
-  "version":  "1.3.1.0",
+  "version":  "1.3.2.0",
   "privacyStatement":  "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA":  "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help":  "https://go.microsoft.com/fwlink/?LinkId=724011",

--- a/businessCentral/src/ADLSESetup.Codeunit.al
+++ b/businessCentral/src/ADLSESetup.Codeunit.al
@@ -8,6 +8,7 @@ codeunit 82560 "ADLSE Setup"
         FieldClassNotSupportedErr: Label 'The field %1 of class %2 is not supported.', Comment = '%1 = field name, %2 = field class';
         SelectTableLbl: Label 'Select the tables to be exported';
         FieldObsoleteNotSupportedErr: Label 'The field %1 is obsolete', Comment = '%1 = field name';
+        FieldDisabledNotSupportedErr: Label 'The field %1 is disabled', Comment = '%1 = field name';
 
     procedure AddTableToExport()
     var
@@ -45,6 +46,8 @@ codeunit 82560 "ADLSE Setup"
             Error(FieldClassNotSupportedErr, Fld."Field Caption", Fld.Class);
         if Fld.ObsoleteState = Fld.ObsoleteState::Removed then
             Error(FieldObsoleteNotSupportedErr, Fld."Field Caption");
+        if not Fld.Enabled then
+            Error(FieldDisabledNotSupportedErr, Fld."Field Caption");
     end;
 
     procedure CheckSetup(var ADLSESetup: Record "ADLSE Setup")


### PR DESCRIPTION
With this change tablefields that have the attribute "Active" set to false are considered NotSupported and not automatically added through "Enable all valid fields". Without this change a runtime error occures when trying to export a disabled field.

Fixes #63