### PR TITLE
Add TableCaption/Entity to Telemetry Logs

### DIFF
--- a/businessCentral/app.json
+++ b/businessCentral/app.json
@@ -4,7 +4,7 @@
   "publisher":  "The bc2adls team, Microsoft Denmark",
   "brief":  "Sync data from Business Central to the Azure storage",
   "description":  "Exports data in chosen tables to the Azure Data Lake and keeps it in sync by incremental updates. Before you use this tool, please read the SUPPORT.md file at https://github.com/microsoft/bc2adls.",
-  "version":  "1.3.2.1",
+  "version":  "1.3.2.2",
   "privacyStatement":  "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA":  "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help":  "https://go.microsoft.com/fwlink/?LinkId=724011",

--- a/businessCentral/src/ADLSEExecute.Codeunit.al
+++ b/businessCentral/src/ADLSEExecute.Codeunit.al
@@ -170,7 +170,7 @@ codeunit 82561 "ADLSE Execute"
                 EntityCount := Format(Rec.Count());
                 CustomDimensions.Add('Entity', TableCaption);
                 CustomDimensions.Add('Entity Count', EntityCount);
-                ADLSEExecution.Log('ADLSE-021', 'Updated records found', Verbosity::Normal, CustomDimensions);             
+                ADLSEExecution.Log('ADLSE-021', 'Updated records found', Verbosity::Normal, CustomDimensions);
             end;
 
             repeat
@@ -212,14 +212,24 @@ codeunit 82561 "ADLSE Execute"
         ADLSEUtil: Codeunit "ADLSE Util";
         ADLSEExecution: Codeunit "ADLSE Execution";
         Rec: RecordRef;
+        CustomDimensions: Dictionary of [Text, Text];
+        TableCaption: Text;
+        EntityCount: Text;
         FlushedTimeStamp: BigInteger;
     begin
         SetFilterForDeletes(TableID, DeletedLastEntryNo, ADLSEDeletedRecord);
 
         if ADLSESeekData.FindRecords(ADLSEDeletedRecord) then begin
-            if EmitTelemetry then
-                ADLSEExecution.Log('ADLSE-010', 'Deleted records found', Verbosity::Verbose);
             Rec.Open(ADLSEDeletedRecord."Table ID");
+
+            if EmitTelemetry then begin
+                TableCaption := Rec.Caption();
+                EntityCount := Format(Rec.Count());
+                CustomDimensions.Add('Entity', TableCaption);
+                CustomDimensions.Add('Entity Count', EntityCount);
+                ADLSEExecution.Log('ADLSE-010', 'Deleted records found', Verbosity::Normal, CustomDimensions);
+            end;
+
             repeat
                 ADLSEUtil.CreateFakeRecordForDeletedAction(ADLSEDeletedRecord, Rec);
                 if ADLSECommunication.TryCollectAndSendRecord(Rec, ADLSEDeletedRecord."Entry No.", FlushedTimeStamp) then
@@ -234,7 +244,7 @@ codeunit 82561 "ADLSE Execute"
                 Error('%1%2', GetLastErrorText(), GetLastErrorCallStack());
         end;
         if EmitTelemetry then
-            ADLSEExecution.Log('ADLSE-011', 'Deleted records exported', Verbosity::Verbose);
+            ADLSEExecution.Log('ADLSE-011', 'Deleted records exported', Verbosity::Normal, CustomDimensions);
     end;
 
     local procedure CreateFieldListForTable(TableID: Integer) FieldIdList: List of [Integer]

--- a/businessCentral/src/ADLSEExecute.Codeunit.al
+++ b/businessCentral/src/ADLSEExecute.Codeunit.al
@@ -224,7 +224,7 @@ codeunit 82561 "ADLSE Execute"
 
             if EmitTelemetry then begin
                 TableCaption := Rec.Caption();
-                EntityCount := Format(Rec.Count());
+                EntityCount := Format(ADLSEDeletedRecord.Count());
                 CustomDimensions.Add('Entity', TableCaption);
                 CustomDimensions.Add('Entity Count', EntityCount);
                 ADLSEExecution.Log('ADLSE-010', 'Deleted records found', Verbosity::Normal, CustomDimensions);


### PR DESCRIPTION
At the moment the Table Caption is only used in the Start-Export Event.  We have no solution to see when the export for a given table started and stopped. With this change you can:
1. See when the export for a given Table started
2. See how many datasets to export are found 
4. See when the export for a given Table finished

This way you can monitor the mean export time per Table and can react to slower exports or find missing SystemModifiedAt keys.

Fixes #65 