### PR TITLE
Removing tracked deleted records should be treated as separate from the export process

### DIFF
--- a/businessCentral/app.json
+++ b/businessCentral/app.json
@@ -4,7 +4,7 @@
   "publisher":  "The bc2adls team, Microsoft Denmark",
   "brief":  "Sync data from Business Central to the Azure storage",
   "description":  "Exports data in chosen tables to the Azure Data Lake and keeps it in sync by incremental updates. Before you use this tool, please read the SUPPORT.md file at https://github.com/microsoft/bc2adls.",
-  "version":  "1.3.3.3",
+  "version":  "1.3.5.1",
   "privacyStatement":  "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA":  "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help":  "https://go.microsoft.com/fwlink/?LinkId=724011",
@@ -24,7 +24,7 @@
   "idRanges": [
     {
       "from": 82560,
-      "to": 82572
+      "to": 82575
     }
   ],
   "target": "Cloud",

--- a/businessCentral/src/ADLSEClearTrackedDeletions.Codeunit.al
+++ b/businessCentral/src/ADLSEClearTrackedDeletions.Codeunit.al
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+codeunit 82573 "ADLSE Clear Tracked Deletions"
+{
+    /// This codeunit removes the tracked deleted records- those that track deletions of records from tables being exported, so 
+    /// that the data lake becomes aware of them and removes those records from the final set of records. Once, these trackings 
+    /// have been exported to the data lake, they are no more required. This codeunit removes such records and may be invoked
+    /// from a job queue that runs at a low- frequency and periodically flushes such data to manage storage space.
+
+    Access = Internal;
+
+    trigger OnRun()
+    begin
+        ClearTrackedDeletedRecords();
+    end;
+
+    var
+        TrackedDeletedRecordsRemovedMsg: Label 'Representations of deleted records that have been exported previously have been deleted.';
+
+    local procedure ClearTrackedDeletedRecords()
+    var
+        ADLSETable: Record "ADLSE Table";
+        ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
+        ADLSEDeletedRecord: Record "ADLSE Deleted Record";
+    begin
+        ADLSETable.SetLoadFields("Table ID");
+        if ADLSETable.FindSet() then
+            repeat
+                ADLSEDeletedRecord.SetRange("Table ID", ADLSETable."Table ID");
+                ADLSEDeletedRecord.SetFilter("Entry No.", '<=%1', ADLSETableLastTimestamp.GetDeletedLastEntryNo(ADLSETable."Table ID"));
+                ADLSEDeletedRecord.DeleteAll();
+
+                ADLSETableLastTimestamp.SaveDeletedLastEntryNo(ADLSETable."Table ID", 0);
+            until ADLSETable.Next() = 0;
+        Message(TrackedDeletedRecordsRemovedMsg);
+    end;
+}

--- a/businessCentral/src/ADLSESetup.Page.al
+++ b/businessCentral/src/ADLSESetup.Page.al
@@ -191,10 +191,8 @@ page 82560 "ADLSE Setup"
                 Enabled = TrackedDeletedRecordsExist;
 
                 trigger OnAction()
-                var
-                    ADLSEExecution: Codeunit "ADLSE Execution";
                 begin
-                    ADLSEExecution.ClearTrackedDeletedRecords();
+                    Codeunit.Run(Codeunit::"ADLSE Clear Tracked Deletions");
                     CurrPage.Update();
                 end;
             }


### PR DESCRIPTION
The export process should focus solely on exporting the upserts and deletes, not clean-up exercises that may slow down the export process. Such actions should be done separately by,
- either, clicking on the action **Clear tracked deleted records** 
- or, invoking the new codeunit **ADLSE Clear Tracked Deletions** through a custom job queue entry 