### PR TITLE
Allow telemetry to be logged at all outputs.

### DIFF
--- a/businessCentral/app.json
+++ b/businessCentral/app.json
@@ -4,7 +4,7 @@
   "publisher":  "The bc2adls team, Microsoft Denmark",
   "brief":  "Sync data from Business Central to the Azure storage",
   "description":  "Exports data in chosen tables to the Azure Data Lake and keeps it in sync by incremental updates. Before you use this tool, please read the SUPPORT.md file at https://github.com/microsoft/bc2adls.",
-  "version":  "1.3.11.2",
+  "version":  "1.3.12.2",
   "privacyStatement":  "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA":  "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help":  "https://go.microsoft.com/fwlink/?LinkId=724011",

--- a/businessCentral/src/ADLSEExecution.Codeunit.al
+++ b/businessCentral/src/ADLSEExecution.Codeunit.al
@@ -109,7 +109,7 @@ codeunit 82569 "ADLSE Execution"
 
     internal procedure Log(EventId: Text; Message: Text; Verbosity: Verbosity; CustomDimensions: Dictionary of [Text, Text])
     begin
-        Session.LogMessage(EventId, Message, Verbosity, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, CustomDimensions);
+        Session.LogMessage(EventId, Message, Verbosity, DataClassification::SystemMetadata, TelemetryScope::All, CustomDimensions);
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::GlobalTriggerManagement, 'OnAfterGetDatabaseTableTriggerSetup', '', true, true)]


### PR DESCRIPTION
Telemetry will now go to all receivers, including the PTE app insights if configured. This change is made to avoid developers from being forced to enter a new application insights key.