### PR TITLE
Bc2adls api add tables and fields

### DIFF
--- a/businessCentral/app.json
+++ b/businessCentral/app.json
@@ -4,7 +4,7 @@
   "publisher":  "The bc2adls team, Microsoft Denmark",
   "brief":  "Sync data from Business Central to the Azure storage",
   "description":  "Exports data in chosen tables to the Azure Data Lake and keeps it in sync by incremental updates. Before you use this tool, please read the SUPPORT.md file at https://github.com/microsoft/bc2adls.",
-  "version":  "1.3.12.3",
+  "version":  "1.3.12.4",
   "privacyStatement":  "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA":  "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help":  "https://go.microsoft.com/fwlink/?LinkId=724011",

--- a/businessCentral/src/ADLSEField.Table.al
+++ b/businessCentral/src/ADLSEField.Table.al
@@ -12,6 +12,15 @@ table 82562 "ADLSE Field"
         {
             Editable = false;
             Caption = 'Table ID';
+            TableRelation = "ADLSE Table"."Table ID";
+
+            trigger OnValidate()
+            var
+                ADLSETable: Record "ADLSE Table";
+            begin
+                if not ADLSETable.Get(Rec."Table ID") then
+                    Error(TableDoesNotExistErr, Rec."Table ID")
+            end;
         }
         field(2; "Field ID"; Integer)
         {
@@ -69,6 +78,9 @@ table 82562 "ADLSE Field"
     begin
         ADLSESetup.CheckNoSimultaneousExportsAllowed();
     end;
+
+    var
+        TableDoesNotExistErr: Label 'Table with ID %1 has not been set to be exported.', Comment = '%1 is the table ID';
 
     procedure InsertForTable(ADLSETable: Record "ADLSE Table")
     var

--- a/businessCentral/src/ADLSEFieldInsertAPI.Page.al
+++ b/businessCentral/src/ADLSEFieldInsertAPI.Page.al
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+page 82567 "ADLSE Field Insert API"
+{
+    PageType = API;
+    APIPublisher = 'bc2adlsTeamMicrosoft';
+    APIGroup = 'bc2adls';
+    APIVersion = 'v1.0';
+    EntityName = 'adlseFieldInsert';
+    EntitySetName = 'adlseFieldsInsert';
+    SourceTable = "ADLSE Field";
+    InsertAllowed = true;
+    ModifyAllowed = false;
+    DeleteAllowed = false;
+    DelayedInsert = true;
+    ODataKeyFields = SystemId;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(GroupName)
+            {
+                field(tableId; Rec."Table ID") { }
+                field(fieldId; Rec."Field ID") { }
+                field(enabled; Rec.Enabled) { }
+                field(systemId; Rec.SystemId)
+                {
+                    Editable = false;
+                }
+            }
+        }
+    }
+}

--- a/businessCentral/src/ADLSETableAPI.Page.al
+++ b/businessCentral/src/ADLSETableAPI.Page.al
@@ -7,7 +7,7 @@ page 82565 "ADLSE Table API"
     APIGroup = 'bc2adls';
     APIVersion = 'v1.0';
     EntityName = 'adlseTable';
-    EntitySetName = 'adlseTable';
+    EntitySetName = 'adlseTables';
     SourceTable = "ADLSE Table";
     InsertAllowed = false;
     DeleteAllowed = false;
@@ -26,10 +26,6 @@ page 82565 "ADLSE Table API"
                 {
                     Editable = false;
                 }
-                field(lastModifiedDateTime; Rec.SystemModifiedAt)
-                {
-                    Editable = false;
-                }
             }
         }
     }
@@ -37,8 +33,26 @@ page 82565 "ADLSE Table API"
     [ServiceEnabled]
     procedure Reset(var ActionContext: WebServiceActionContext)
     begin
-        Rec.reset();
-        SetActionResponse(ActionContext, Rec."SystemId");
+        Rec.Mark(true);
+        Rec.MarkedOnly();
+        Rec.ResetSelected();
+        SetActionResponse(ActionContext, Rec.SystemId);
+    end;
+
+    [ServiceEnabled]
+    procedure Enable(var ActionContext: WebServiceActionContext)
+    begin
+        Rec.Validate(Enabled, true);
+        Rec.Modify(true);
+        SetActionResponse(ActionContext, Rec.SystemId);
+    end;
+
+    [ServiceEnabled]
+    procedure Disable(var ActionContext: WebServiceActionContext)
+    begin
+        Rec.Validate(Enabled, false);
+        Rec.Modify(true);
+        SetActionResponse(ActionContext, Rec.SystemId);
     end;
 
     local procedure SetActionResponse(var ActionContext: WebServiceActionContext; AdlsId: Guid)

--- a/businessCentral/src/ADLSETableAPI.Page.al
+++ b/businessCentral/src/ADLSETableAPI.Page.al
@@ -32,26 +32,39 @@ page 82565 "ADLSE Table API"
 
     [ServiceEnabled]
     procedure Reset(var ActionContext: WebServiceActionContext)
+    var
+        SelectedADLSETable: Record "ADLSE Table";
     begin
-        Rec.Mark(true);
-        Rec.MarkedOnly();
-        Rec.ResetSelected();
+        CurrPage.SetSelectionFilter(SelectedADLSETable);
+        SelectedADLSETable.ResetSelected();
         SetActionResponse(ActionContext, Rec.SystemId);
     end;
 
     [ServiceEnabled]
     procedure Enable(var ActionContext: WebServiceActionContext)
+    var
+        SelectedADLSETable: Record "ADLSE Table";
     begin
-        Rec.Validate(Enabled, true);
-        Rec.Modify(true);
+        CurrPage.SetSelectionFilter(SelectedADLSETable);
+        if SelectedADLSETable.FindSet(true) then
+            repeat
+                SelectedADLSETable.Validate(Enabled, true);
+                SelectedADLSETable.Modify(true);
+            until SelectedADLSETable.Next() = 0;
         SetActionResponse(ActionContext, Rec.SystemId);
     end;
 
     [ServiceEnabled]
     procedure Disable(var ActionContext: WebServiceActionContext)
+    var
+        SelectedADLSETable: Record "ADLSE Table";
     begin
-        Rec.Validate(Enabled, false);
-        Rec.Modify(true);
+        CurrPage.SetSelectionFilter(SelectedADLSETable);
+        if SelectedADLSETable.FindSet(true) then
+            repeat
+                SelectedADLSETable.Validate(Enabled, false);
+                SelectedADLSETable.Modify(true);
+            until SelectedADLSETable.Next() = 0;
         SetActionResponse(ActionContext, Rec.SystemId);
     end;
 

--- a/businessCentral/src/ADLSETableInsertAPI.Page.al
+++ b/businessCentral/src/ADLSETableInsertAPI.Page.al
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+page 82568 "ADLSE Table Insert API"
+{
+    PageType = API;
+    APIPublisher = 'bc2adlsTeamMicrosoft';
+    APIGroup = 'bc2adls';
+    APIVersion = 'v1.0';
+    EntityName = 'adlseTableInsert';
+    EntitySetName = 'adlseTablesInsert';
+    SourceTable = "ADLSE Table";
+    InsertAllowed = true;
+    DeleteAllowed = false;
+    ModifyAllowed = false;
+    DelayedInsert = true;
+    ODataKeyFields = SystemId;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(GroupName)
+            {
+                field(tableId; Rec."Table ID") { }
+                field(enabled; Rec.Enabled) { }
+                field(systemId; Rec.SystemId)
+                {
+                    Editable = false;
+                }
+            }
+            part(adlseFields; "ADLSE Field Insert API")
+            {
+                EntityName = 'adlseFieldInsert';
+                EntitySetName = 'adlseFieldsInsert';
+                SubPageLink = "Table ID" = field("Table ID");
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Users have a need to query and insert export schema records through the API. The following changes have been made,

- Tables and Fields can be inserted
- Users should be able to reset, enable or disable tables